### PR TITLE
Fix a typo in Multi-GPU guide

### DIFF
--- a/guides/distributed_training.py
+++ b/guides/distributed_training.py
@@ -364,7 +364,7 @@ disk (which is typically temporary), **except worker 0**, which would save Tenso
 logs checkpoints to a Cloud storage location for later access & reuse.
 
 The evaluator would simply use `MirroredStrategy` (since it runs on a single machine and
-does need to communicate with other machines) and call `model.evaluate()`. It would be
+does not need to communicate with other machines) and call `model.evaluate()`. It would be
 loading the latest checkpoint saved by the chief worker to a Cloud storage location, and
 would save evaluation logs to the same location as the chief logs.
 


### PR DESCRIPTION
In the distributed training guide,  line [367](https://github.com/keras-team/keras-io/blob/6e6ffd12e95c068f0290c9589aa1d6ce721fcb64/guides/distributed_training.py#L367), it should be `since it runs on a single machine and does **not** need to communicate with other machines` instead of `since it runs on a single machine and does need to communicate with other machines`